### PR TITLE
Fix GP call lifecycle: block duplicate patient calls and hide ended c…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:call-flow": "node scripts/test-call-flow.mjs"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/scripts/test-call-flow.mjs
+++ b/scripts/test-call-flow.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { applyIncomingCallEvent } from "../src/utils/incomingCallSse.js";
+import { filterDismissedCalls, dismissIncomingCallId } from "../src/utils/dismissedIncomingCalls.js";
+
+// applyIncomingCallEvent
+let list = [{ callId: 1 }, { callId: 2 }];
+list = applyIncomingCallEvent(list, { type: "CALL_ENDED", callId: 1 });
+assert.equal(list.length, 1);
+assert.equal(list[0].callId, 2);
+
+list = applyIncomingCallEvent(list, {
+  type: "NEW_CALL",
+  call: { callId: 3, patientFirstName: "A" },
+});
+assert.equal(list.length, 2);
+assert.equal(list[0].callId, 3);
+
+list = applyIncomingCallEvent(list, { type: "NEW_CALL", call: { callId: 1 } }, [1]);
+assert.equal(list.length, 2);
+
+list = applyIncomingCallEvent(
+  [{ callId: 10 }],
+  { type: "CONNECTED", calls: [{ callId: 10 }, { callId: 11 }] },
+  [10],
+);
+assert.deepEqual(list.map((c) => c.callId), [11]);
+
+// dismissedIncomingCalls (in-memory shim for localStorage)
+const mem = new Map();
+globalThis.localStorage = {
+  getItem: (k) => mem.get(k) ?? null,
+  setItem: (k, v) => mem.set(k, v),
+  removeItem: (k) => mem.delete(k),
+};
+
+dismissIncomingCallId(42);
+const filtered = filterDismissedCalls([
+  { callId: 42 },
+  { callId: 99 },
+]);
+assert.equal(filtered.length, 1);
+assert.equal(filtered[0].callId, 99);
+
+console.log("call-flow tests passed");

--- a/src/PatientDashboard/PatientLayout.jsx
+++ b/src/PatientDashboard/PatientLayout.jsx
@@ -306,6 +306,8 @@ import {
   usePartnerLocations,
 } from "../context/PartnerLocationsContext";
 import { getPatientPartnerSlug } from "../utils";
+import { openVideoCallInNewTab } from "../utils/videoCallNavigation";
+import { parseApiError } from "../utils/parseApiError";
 
 const FIRST_CARE_HOSPITAL_SLUG = "first-care-hospital";
 const LOGO_SRC = "/logo.jpeg";
@@ -388,17 +390,16 @@ export default function PatientLayout() {
     try {
       const response = await axios.post(
         `${baseUrl}/api/v1/video/create-meeting?patientId=${patientId}`,
-        { headers: { Authorization: `Bearer ${token}` } }
+        {},
+        { headers: { Authorization: `Bearer ${token}` } },
       );
 
       const roomUrl = response.data?.roomUrl;
       if (roomUrl) {
-        window.open(roomUrl, "_blank", "noopener,noreferrer");
+        openVideoCallInNewTab(roomUrl);
       }
     } catch (error) {
-      if (error.message === "Network Error") makePaymentToast(error.message);
-      const responseData = error.response?.data;
-      if (responseData?.error) makePaymentToast(responseData.error);
+      makePaymentToast(parseApiError(error, "Failed to start call."));
     }
   };
 

--- a/src/PatientDashboard/dashboard.jsx
+++ b/src/PatientDashboard/dashboard.jsx
@@ -24,6 +24,13 @@ import {
   flattenSpecialistsFromApi,
 } from "../utils/fetchDoctorForPatient";
 import { openVideoCallInNewTab } from "../utils/videoCallNavigation";
+import { parseApiError } from "../utils/parseApiError";
+import {
+  clearPatientGpCall,
+  isPatientGpCallActive,
+  loadPatientGpCall,
+  savePatientGpCall,
+} from "../utils/patientGpCall";
 import {
   joinScheduledAppointment,
   parseJoinError,
@@ -301,6 +308,56 @@ const Dashboard = () => {
     if (stored) setActiveMeeting(stored);
   }, []);
 
+  // Restore in-progress GP call (prevents duplicate "Start call")
+  useEffect(() => {
+    const storedCall = loadPatientGpCall();
+    if (!storedCall?.callId || !token) return;
+
+    if (storedCall.status !== "WAITING") return;
+
+    const callId = storedCall.callId;
+    setCurrentCallId(callId);
+    setCallStatus("WAITING");
+    if (storedCall.roomUrl) {
+      setVideoLink({ roomUrl: storedCall.roomUrl, meetingId: callId });
+    }
+
+    if (pollingInterval) return undefined;
+
+    const waitStartedAt = storedCall.startedAt || Date.now();
+    const interval = setInterval(async () => {
+      const status = await pollCallStatus(callId);
+      if (status === "DOCTOR_JOINED") {
+        clearInterval(interval);
+        setPollingInterval(null);
+        savePatientGpCall({
+          callId,
+          roomUrl: storedCall.roomUrl,
+          status: "IN_CALL",
+        });
+        if (storedCall.roomUrl) {
+          saveActiveMeetingToStorage(storedCall.roomUrl, 40);
+          openVideoCallInNewTab(storedCall.roomUrl);
+        }
+        setIsCallADoctorModalOpen(false);
+        setCallStatus(null);
+        clearPatientGpCall();
+      } else if (
+        status === "ENDED" ||
+        Date.now() - waitStartedAt >= CALL_WAIT_TIMEOUT_MS
+      ) {
+        clearInterval(interval);
+        setPollingInterval(null);
+        setCallStatus("NO_DOCTOR");
+        clearPatientGpCall();
+      }
+    }, 3000);
+    setPollingInterval(interval);
+
+    return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
+
   // Reaper to clear expired active meetings
   useEffect(() => {
     const interval = setInterval(() => {
@@ -425,6 +482,7 @@ const Dashboard = () => {
 
   const handleTryCallAgain = () => {
     clearCallPolling();
+    clearPatientGpCall();
     setCallStatus(null);
     setCurrentCallId(null);
     setVideoLink(null);
@@ -593,6 +651,14 @@ const Dashboard = () => {
   };
 
   const createMeeting = async () => {
+    if (callStatus === "WAITING" || isPatientGpCallActive()) {
+      toast.info(
+        "You already have an active call. Cancel it or wait for a doctor before starting another.",
+      );
+      setIsCallADoctorModalOpen(true);
+      return;
+    }
+
     setIsLoading(true);
 
     try {
@@ -622,6 +688,11 @@ const Dashboard = () => {
 
       setCurrentCallId(callId);
       setCallStatus("WAITING");
+      savePatientGpCall({
+        callId,
+        roomUrl: response.data?.roomUrl,
+        status: "WAITING",
+      });
 
       const waitStartedAt = Date.now();
 
@@ -633,6 +704,11 @@ const Dashboard = () => {
           setCallStatus("DOCTOR_JOINED");
           clearInterval(interval);
           setPollingInterval(null);
+          savePatientGpCall({
+            callId,
+            roomUrl: response.data?.roomUrl,
+            status: "IN_CALL",
+          });
 
           if (response.data?.roomUrl) {
             saveActiveMeetingToStorage(response.data.roomUrl, 40);
@@ -646,6 +722,7 @@ const Dashboard = () => {
           }
           setIsCallADoctorModalOpen(false);
           setCallStatus(null);
+          clearPatientGpCall();
         } else if (
           status === "ENDED" ||
           Date.now() - waitStartedAt >= CALL_WAIT_TIMEOUT_MS
@@ -653,6 +730,7 @@ const Dashboard = () => {
           clearInterval(interval);
           setPollingInterval(null);
           setCallStatus("NO_DOCTOR");
+          clearPatientGpCall();
         }
       }, 3000);
 
@@ -660,8 +738,11 @@ const Dashboard = () => {
       return response.data;
     } catch (err) {
       console.error("Create meeting error:", err);
-      toast.error(err.response?.data?.error || "Failed to create meeting");
+      toast.error(
+        parseApiError(err, "Failed to create meeting. Please try again in a moment."),
+      );
       setCallStatus(null);
+      clearPatientGpCall();
     } finally {
       setIsLoading(false);
     }
@@ -720,6 +801,7 @@ const Dashboard = () => {
       setCallStatus(null);
       setCurrentCallId(null);
       setVideoLink(null);
+      clearPatientGpCall();
       setIsCallADoctorModalOpen(false);
       setIsCancelCallConfirmOpen(false);
 
@@ -740,6 +822,7 @@ const Dashboard = () => {
       setCallStatus(null);
       setCurrentCallId(null);
       setVideoLink(null);
+      clearPatientGpCall();
       setIsCallADoctorModalOpen(false);
     } finally {
       setIsLoading(false);

--- a/src/components/VideoCall.jsx
+++ b/src/components/VideoCall.jsx
@@ -14,6 +14,8 @@ import ConsultationFeedbackModal from "./ConsultationFeedbackModal";
 import { getStoredCallContext } from "../utils/videoCallDisplayInfo";
 import { resolveVideoCallRoomUrl } from "../utils/videoCallRoomUrl";
 import { useVideoCallHeader } from "../hooks/useVideoCallHeader";
+import { dismissIncomingCallId } from "../utils/dismissedIncomingCalls";
+import { clearPatientGpCall } from "../utils/patientGpCall";
 
 function formatHeaderParticipantName(displayInfo) {
   if (!displayInfo) return "Loading...";
@@ -104,7 +106,13 @@ function VideoCallRoom({ roomUrl, userData, call, callFromRedux }) {
   const hasJoinedRef = useRef(false);
 
   const finishLeaveAndRedirect = (redirectPath) => {
+    const endedCallId =
+      call?.callId ?? call?.id ?? call?.meetingId ?? null;
+    if (endedCallId != null) {
+      dismissIncomingCallId(endedCallId);
+    }
     clearCallPersistence();
+    clearPatientGpCall();
     dispatch(setRoomUrl(null));
     dispatch(setCall(null));
 

--- a/src/components/dashboard/WelcomeBack/IncomingCall.jsx
+++ b/src/components/dashboard/WelcomeBack/IncomingCall.jsx
@@ -11,6 +11,7 @@ import NoCalls from "../../../assets/NoCalls";
 import { getToken } from "../../../utils";
 import { openVideoCallPreferNewTab } from "../../../utils/videoCallNavigation";
 import { useIncomingCallSse } from "../../../hooks/useIncomingCallSse";
+import { dismissIncomingCallId } from "../../../utils/dismissedIncomingCalls";
 
 const IncomingCall = () => {
   const [joiningCallId, setJoiningCallId] = useState(null);
@@ -118,6 +119,7 @@ const IncomingCall = () => {
           localStorage.setItem("pickedCalls", JSON.stringify(picked));
           setPickedCalls(picked);
         }
+        dismissIncomingCallId(callId);
 
         try {
           const expiresAt = Date.now() + 40 * 60 * 1000;

--- a/src/hooks/useIncomingCallSse.js
+++ b/src/hooks/useIncomingCallSse.js
@@ -4,6 +4,10 @@ import {
   applyIncomingCallEvent,
   connectIncomingCallSse,
 } from "../utils/incomingCallSse";
+import {
+  dismissIncomingCallId,
+  loadDismissedCallIds,
+} from "../utils/dismissedIncomingCalls";
 
 const FALLBACK_POLL_MS = 30000;
 const RECONNECT_DELAY_MS = 5000;
@@ -25,6 +29,7 @@ export function useIncomingCallSse({
   const pollRef = useRef(null);
   const reconnectRef = useRef(null);
   const pickedRef = useRef(pickedCallIds);
+  const dismissedRef = useRef(loadDismissedCallIds());
 
   pickedRef.current = pickedCallIds;
 
@@ -33,8 +38,9 @@ export function useIncomingCallSse({
     try {
       const data = await fetchCalls();
       const picked = pickedRef.current || [];
+      const dismissed = dismissedRef.current || [];
       setCalls(
-        (data || []).filter((c) => !picked.includes(c.callId))
+        applyIncomingCallEvent(data || [], { type: "REFRESH", calls: data || [] }, picked, dismissed),
       );
     } finally {
       setReady(true);
@@ -43,8 +49,21 @@ export function useIncomingCallSse({
 
   const handleEvent = useCallback((event) => {
     if (event.type === "HEARTBEAT") return;
+    if (event.type === "CALL_ENDED" && event.callId != null) {
+      dismissIncomingCallId(event.callId);
+      dismissedRef.current = loadDismissedCallIds();
+    }
+    if (event.type === "CALL_CLAIMED" && event.callId != null) {
+      dismissIncomingCallId(event.callId);
+      dismissedRef.current = loadDismissedCallIds();
+    }
     setCalls((prev) =>
-      applyIncomingCallEvent(prev, event, pickedRef.current)
+      applyIncomingCallEvent(
+        prev,
+        event,
+        pickedRef.current,
+        dismissedRef.current,
+      ),
     );
   }, []);
 
@@ -88,8 +107,14 @@ export function useIncomingCallSse({
   }, [enabled, connect, loadCalls]);
 
   useEffect(() => {
+    dismissedRef.current = loadDismissedCallIds();
     setCalls((prev) =>
-      prev.filter((c) => !pickedCallIds.includes(c.callId))
+      applyIncomingCallEvent(
+        prev,
+        { type: "REFRESH", calls: prev },
+        pickedCallIds,
+        dismissedRef.current,
+      ),
     );
   }, [pickedCallIds]);
 

--- a/src/utils/dismissedIncomingCalls.js
+++ b/src/utils/dismissedIncomingCalls.js
@@ -1,0 +1,33 @@
+const STORAGE_KEY = "dismissedIncomingCallIds";
+
+function normalizeId(id) {
+  if (id == null) return null;
+  const n = Number(id);
+  return Number.isFinite(n) ? n : id;
+}
+
+export function loadDismissedCallIds() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const list = JSON.parse(raw || "[]");
+    if (!Array.isArray(list)) return [];
+    return list.map(normalizeId).filter((id) => id != null);
+  } catch {
+    return [];
+  }
+}
+
+export function dismissIncomingCallId(callId) {
+  const id = normalizeId(callId);
+  if (id == null) return;
+  const existing = loadDismissedCallIds();
+  if (existing.some((x) => x === id)) return;
+  const next = [...existing, id].slice(-200);
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+}
+
+export function filterDismissedCalls(calls, dismissedIds = loadDismissedCallIds()) {
+  if (!dismissedIds?.length) return calls || [];
+  const hidden = new Set(dismissedIds);
+  return (calls || []).filter((c) => !hidden.has(normalizeId(c.callId)));
+}

--- a/src/utils/incomingCallSse.js
+++ b/src/utils/incomingCallSse.js
@@ -90,23 +90,42 @@ export function connectIncomingCallSse({
   };
 }
 
-/** Apply SSE payload to a call list (CallResponse / VideoCallResponse shape). */
-export function applyIncomingCallEvent(calls, event, pickedCallIds = []) {
-  const list = Array.isArray(calls) ? [...calls] : [];
-  const isPicked = (id) => pickedCallIds.includes(id);
+function normalizeCallId(id) {
+  if (id == null) return null;
+  const n = Number(id);
+  return Number.isFinite(n) ? n : id;
+}
 
-  if (!event?.type) return list;
+function isHiddenCallId(id, hiddenIds) {
+  const normalized = normalizeCallId(id);
+  return hiddenIds.some((h) => normalizeCallId(h) === normalized);
+}
+
+/** Apply SSE payload to a call list (CallResponse / VideoCallResponse shape). */
+export function applyIncomingCallEvent(
+  calls,
+  event,
+  pickedCallIds = [],
+  dismissedCallIds = [],
+) {
+  const list = Array.isArray(calls) ? [...calls] : [];
+  const hiddenIds = [...pickedCallIds, ...dismissedCallIds];
+  const isHidden = (id) => isHiddenCallId(id, hiddenIds);
+
+  if (!event?.type) return list.filter((c) => !isHidden(c.callId));
 
   switch (event.type) {
     case "CONNECTED":
     case "REFRESH":
-      return (event.calls || []).filter((c) => !isPicked(c.callId));
+      return (event.calls || []).filter((c) => !isHidden(c.callId));
     case "NEW_CALL":
-      if (event.call && !isPicked(event.call.callId)) {
-        const exists = list.some((c) => c.callId === event.call.callId);
+      if (event.call && !isHidden(event.call.callId)) {
+        const exists = list.some(
+          (c) => normalizeCallId(c.callId) === normalizeCallId(event.call.callId),
+        );
         if (!exists) list.unshift(event.call);
       }
-      return list;
+      return list.filter((c) => !isHidden(c.callId));
     case "CALL_CLAIMED":
     case "CALL_ENDED":
       return list.filter((c) => c.callId !== event.callId);

--- a/src/utils/parseApiError.js
+++ b/src/utils/parseApiError.js
@@ -1,0 +1,13 @@
+/** Extract a user-visible message from axios / API errors. */
+export function parseApiError(error, fallback = "Something went wrong. Please try again.") {
+  const data = error?.response?.data;
+  if (typeof data === "string" && data.trim()) return data.trim();
+  if (data?.error) return String(data.error);
+  if (data?.exceptionMessage) return String(data.exceptionMessage);
+  if (data?.message) return String(data.message);
+  if (error?.message === "Network Error") {
+    return "Network error — check your connection and try again.";
+  }
+  if (error?.message) return error.message;
+  return fallback;
+}

--- a/src/utils/patientGpCall.js
+++ b/src/utils/patientGpCall.js
@@ -1,0 +1,35 @@
+const STORAGE_KEY = "patientGpCall";
+
+/** @returns {{ callId: string|number, roomUrl?: string, status: string, startedAt: number } | null} */
+export function loadPatientGpCall() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed?.callId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function savePatientGpCall({ callId, roomUrl, status = "WAITING" }) {
+  if (callId == null) return;
+  const payload = {
+    callId: String(callId),
+    roomUrl: roomUrl || null,
+    status,
+    startedAt: Date.now(),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+}
+
+export function clearPatientGpCall() {
+  localStorage.removeItem(STORAGE_KEY);
+}
+
+/** True while patient has an outstanding GP instant call (waiting or in session). */
+export function isPatientGpCallActive(stored = loadPatientGpCall()) {
+  if (!stored?.callId) return false;
+  return stored.status === "WAITING" || stored.status === "IN_CALL";
+}


### PR DESCRIPTION
…alls for doctors

Persist active patient GP call state, dismiss ended/claimed calls from doctor incoming list via SSE and local storage, improve create-meeting error parsing, and add call-flow unit tests.